### PR TITLE
Fix for DNN-9537

### DIFF
--- a/DNN Platform/Modules/Journal/Scripts/journal.js
+++ b/DNN Platform/Modules/Journal/Scripts/journal.js
@@ -619,6 +619,7 @@ function pluginInit() {
                 $(opts.previewSelector + ' #imgCount').text(currImage + 1 + ' of ' + images.length);
                 $(opts.previewSelector + ' #imagePreviewer').show();
             } else {
+                journalItem.ItemData.ImageUrl = '';
                 $(opts.previewSelector + ' #imagePreviewer').hide();
             }
             if (link.Description == null) {


### PR DESCRIPTION
Fixes bad ItemData JSON record when there is no IMAGE found in a URL that is in "preview" in the Journal Module.